### PR TITLE
Refresh the dataset daily: last activity has been frozen since May 2025

### DIFF
--- a/.github/workflows/refresh.yml
+++ b/.github/workflows/refresh.yml
@@ -1,0 +1,109 @@
+name: Refresh data
+
+# Rebuilds the dataset and redeploys the site. The published pages only ever
+# show the metadata captured by the last crawl, so without this the "last
+# activity" of every repository silently ages.
+
+on:
+  schedule:
+    # daily, off the hour to avoid the peak of scheduled workflows
+    - cron: "37 3 * * *"
+  workflow_dispatch:
+    inputs:
+      only:
+        description: "Comma separated config.yaml entries (default: all)"
+        required: false
+        type: string
+      max_repos:
+        description: "Stop after N repositories"
+        required: false
+        type: string
+
+concurrency:
+  group: refresh-data
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+env:
+  # holds sqlite.db.gz between runs, the database is not tracked by git
+  DB_RELEASE_TAG: data
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    # a full refresh of ~18k repositories takes ~40 minutes, the limit is
+    # latency and not the rate limit budget
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 11
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Restore database
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if gh release download "$DB_RELEASE_TAG" --pattern sqlite.db.gz --clobber; then
+            gunzip -f sqlite.db.gz
+            echo "restored $(du -h sqlite.db | cut -f1) database"
+          else
+            echo "no database published yet, starting from an empty one"
+          fi
+
+      - name: Apply migrations
+        run: pnpm migrate
+
+      - name: Crawl
+        env:
+          # optional: a comma separated list of PATs belonging to *different*
+          # accounts. the hourly quota is per account, and the built-in token
+          # is limited to 1000 requests/hour per repository.
+          GITHUB_TOKEN: ${{ secrets.CRAWL_GITHUB_TOKEN || github.token }}
+          # through the environment rather than inlined in the script, so a
+          # dispatch input cannot inject shell
+          ONLY: ${{ inputs.only }}
+          MAX_REPOS: ${{ inputs.max_repos }}
+        run: |
+          pnpm crawl ${ONLY:+--only="$ONLY"} ${MAX_REPOS:+--max-repos="$MAX_REPOS"}
+
+      # even when the crawl failed halfway: rows are committed batch by batch,
+      # so keeping them lets the next run resume instead of starting over
+      - name: Publish database
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          [ -f sqlite.db ] || exit 0
+          gzip -9 -c sqlite.db > sqlite.db.gz
+          gh release view "$DB_RELEASE_TAG" >/dev/null 2>&1 || \
+            gh release create "$DB_RELEASE_TAG" \
+              --title "Dataset" \
+              --notes "Crawled dataset the site is built from. Updated by the refresh workflow." \
+              --latest=false
+          gh release upload "$DB_RELEASE_TAG" sqlite.db.gz --clobber
+
+      - name: Build
+        run: pnpm build
+
+      - name: Deploy
+        run: |
+          cd out
+          git init -q -b pages
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git commit -q -m "deploy from ${GITHUB_SHA::7}"
+          git push -q --force \
+            "https://x-access-token:${{ github.token }}@github.com/${{ github.repository }}.git" \
+            pages

--- a/.gitignore
+++ b/.gitignore
@@ -37,8 +37,8 @@ next-env.d.ts
 
 /public/aggregated/*
 .end
-/bin
 /.vscode
 /out
 /sqlite.db
+/sqlite.db.gz
 .env

--- a/README.md
+++ b/README.md
@@ -20,6 +20,35 @@ AwesomeExplorer is a web application designed to enhance the way you browse GitH
 
 To start using AwesomeExplorer, simply visit our website https://awexplor.github.io/ and begin exploring your favorite awesome lists with newfound ease and efficiency.
 
+## How the data is refreshed
+
+Every figure shown on a card — stars, forks and especially the *last activity*
+(`pushed_at`) — is a snapshot taken when the dataset was crawled, stored in a
+local `sqlite.db` and frozen into `public/aggregated/<list>.json` at build time.
+Nothing is fetched from GitHub at runtime, so the pages are only as fresh as the
+last crawl.
+
+```bash
+pnpm install
+pnpm migrate                 # create/upgrade sqlite.db
+GITHUB_TOKEN=… pnpm crawl    # refresh the dataset
+pnpm build                   # export the static site to out/
+```
+
+`pnpm crawl --help` lists the options (`--only`, `--stale-days`, `--max-repos`,
+…). A full refresh covers ~18k repositories with ~360 GraphQL requests, which
+fits well inside the hourly quota. `GITHUB_TOKEN` accepts several comma
+separated tokens; they only add budget if they belong to *different* accounts,
+since the 5000 requests/hour limit is per account.
+
+The `Refresh data` workflow runs this daily and redeploys the `pages` branch. It
+keeps `sqlite.db` between runs as a release asset, and works with the built-in
+token; set the `CRAWL_GITHUB_TOKEN` secret to use a wider quota.
+
+Star history (`stars_detail`, used for the trending order) is not part of the
+crawl: it requires paginating the stargazers of every repository, roughly 50k
+requests, so it needs its own token budget.
+
 ## Explorerable repositories
 
 Currently, we feature a selection of popular awesome list projects due to GitHub API rate limits and the limited number of API tokens available. If you'd like to see a specific awesome list repository included, please [open an issue](https://github.com/AweXplor/awexplor.github.io/issues/new) and we will consider adding it.

--- a/app/aggregated/[slug]/page.tsx
+++ b/app/aggregated/[slug]/page.tsx
@@ -69,6 +69,8 @@ async function renderToPublic(slug: string) {
   const filePath = path.join("public", "aggregated", `${slug}.json`);
 
   try {
+    // not tracked by git, so it is missing on a fresh checkout
+    await fs.mkdir(path.dirname(filePath), { recursive: true });
     await fs.writeFile(filePath, jsonContent, "utf-8");
   } catch (error) {
     console.error(`Failed to save ${slug}.json:`, error);

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,11 +3,48 @@ import "react-notion-x/src/styles.css";
 import { NotionAPI } from "notion-client";
 import NotionRenderer from "./notion-renderer";
 
+const NOTION_PAGE =
+  "https://adevday.notion.site/Awesome-Explorer-1357a7280fe5807aa7a4f3c9e284ad3e";
+
+// notion.so answers 403 Forbidden to the default node user agent, which fails
+// the whole static export
+const notion = new NotionAPI({
+  kyOptions: {
+    headers: {
+      "user-agent":
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 " +
+        "(KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36",
+    },
+  },
+});
+
+/**
+ * Notion wraps every record in an extra `value` level since __version__ 3,
+ * react-notion-x still reads the flat `record.value` shape.
+ */
+function normalizeRecordMap<T>(recordMap: T) {
+  for (const table of Object.values(recordMap as Record<string, unknown>)) {
+    if (!table || typeof table !== "object") continue;
+    for (const record of Object.values(table) as any[]) {
+      if (record?.value?.value) record.value = record.value.value;
+    }
+  }
+  return recordMap;
+}
+
+async function getPage(attempts = 3) {
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return normalizeRecordMap(await notion.getPage(NOTION_PAGE));
+    } catch (error) {
+      if (attempt >= attempts) throw error;
+      await new Promise((resolve) => setTimeout(resolve, attempt * 2000));
+    }
+  }
+}
+
 export default async function HomePage() {
-  const notion = new NotionAPI();
-  const recordMap = await notion.getPage(
-    "https://adevday.notion.site/Awesome-Explorer-1357a7280fe5807aa7a4f3c9e284ad3e",
-  );
+  const recordMap = await getPage();
 
   return (
     <NotionRenderer recordMap={recordMap} fullPage={true} darkMode={false} />

--- a/bin/crawl.ts
+++ b/bin/crawl.ts
@@ -1,0 +1,394 @@
+/**
+ * Refreshes the sqlite dataset the static site is built from.
+ *
+ * 1. reads every awesome list declared in config.yaml and extracts the
+ *    repositories linked in its README
+ * 2. refreshes the metadata of those repositories (stars, forks, pushedAt,
+ *    language, topics, license, archived)
+ *
+ * The GitHub REST API allows 5000 requests/hour per *account* (1000/hour for
+ * the built-in Actions token), and the dataset holds ~18k repositories, so the
+ * metadata pass goes through GraphQL where one request resolves a whole batch.
+ * A full refresh costs ~360 requests / ~1800 rate limit points.
+ *
+ * Star history (github_repo.stars_detail) is deliberately not refreshed here:
+ * it needs a paginated walk over the stargazers of every repository, which
+ * alone is ~50k requests. Run it separately with a dedicated token budget.
+ *
+ * Usage: pnpm crawl [--only=rust,golang] [--stale-days=7] [--max-repos=5000]
+ */
+import "dotenv/config";
+import * as D from "drizzle-orm";
+import { parseArgs } from "node:util";
+import PQueue from "p-queue";
+import { loadConfig } from "../lib/config.ts";
+import { db } from "../lib/db/index.ts";
+import { awesomeRepoTable, githubRepoTable } from "../lib/db/schema.ts";
+import { getAwesomeSourceIdsFromConfig } from "../lib/db/utils.ts";
+import {
+  fetchAwesomeRepo,
+  fetchGithubProjects,
+  rotateOctokit,
+  type GithubProject,
+} from "../lib/fetcher/github.ts";
+
+const { values: flags } = parseArgs({
+  options: {
+    only: { type: "string" },
+    "batch-size": { type: "string", default: "50" },
+    concurrency: { type: "string", default: "8" },
+    "stale-days": { type: "string" },
+    "max-repos": { type: "string" },
+    "skip-readme": { type: "boolean", default: false },
+    "dry-run": { type: "boolean", default: false },
+    help: { type: "boolean", default: false },
+  },
+});
+
+if (flags.help) {
+  console.log(`pnpm crawl [options]
+
+  --only=rust,golang   only crawl these config.yaml entries (default: all)
+  --stale-days=N       skip repositories refreshed less than N days ago
+  --max-repos=N        stop after N repositories (the stalest ones first)
+  --batch-size=N       repositories per GraphQL request (default 50, max 100)
+  --concurrency=N      parallel requests (default 8, stay well under 100)
+  --skip-readme        reuse the repository lists already in the database
+  --dry-run            fetch everything but write nothing
+`);
+  process.exit(0);
+}
+
+const BATCH_SIZE = Math.min(Number(flags["batch-size"]) || 50, 100);
+const CONCURRENCY = Number(flags.concurrency) || 8;
+const STALE_DAYS = flags["stale-days"]
+  ? Number(flags["stale-days"])
+  : undefined;
+const MAX_REPOS = flags["max-repos"] ? Number(flags["max-repos"]) : undefined;
+const DRY_RUN = flags["dry-run"];
+
+if (!process.env["GITHUB_TOKEN"]) {
+  console.error(
+    "GITHUB_TOKEN is not set. Provide one token, or several comma separated " +
+      "ones belonging to different accounts (the hourly quota is per account).",
+  );
+  process.exit(1);
+}
+
+// github.com paths that look like <owner>/<repo> but are not repositories
+const RESERVED_OWNERS = new Set([
+  "about",
+  "account",
+  "apps",
+  "codespaces",
+  "collections",
+  "contact",
+  "dashboard",
+  "enterprise",
+  "explore",
+  "features",
+  "issues",
+  "join",
+  "login",
+  "marketplace",
+  "new",
+  "notifications",
+  "organizations",
+  "orgs",
+  "pricing",
+  "pulls",
+  "search",
+  "security",
+  "settings",
+  "site",
+  "sponsors",
+  "stars",
+  "topics",
+  "trending",
+  "users",
+  "watching",
+]);
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+/**
+ * Retries around the two failure modes of a long crawl: rate limits (rotate to
+ * the next token, or wait for the window to reset) and transient 5xx/network
+ * errors. Anything permanently gone resolves to undefined so the crawl goes on.
+ */
+async function withRetry<T>(
+  label: string,
+  fn: () => Promise<T>,
+): Promise<T | undefined> {
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return await fn();
+    } catch (e: any) {
+      const status = e?.status ?? e?.response?.status;
+      if (status === 404 || status === 451) return undefined;
+      if (status === 403 || status === 429) {
+        if (rotateOctokit()) continue;
+        const reset = Number(e?.response?.headers?.["x-ratelimit-reset"]);
+        const waitMs = Number.isFinite(reset)
+          ? Math.max(reset * 1000 - Date.now(), 0) + 5_000
+          : attempt * 60_000;
+        const capped = Math.min(waitMs, 65 * 60_000);
+        console.warn(
+          `[rate limit] ${label}: waiting ${Math.round(capped / 1000)}s`,
+        );
+        await sleep(capped);
+        continue;
+      }
+      if (attempt >= 4) {
+        console.warn(`[skip] ${label}: ${e?.message ?? e}`);
+        return undefined;
+      }
+      await sleep(attempt * 2_000);
+    }
+  }
+}
+
+function normalizeId(raw: string) {
+  const [owner, rest] = raw.split("/");
+  if (!owner || !rest) return undefined;
+  if (RESERVED_OWNERS.has(owner.toLowerCase())) return undefined;
+  const repo = rest.replace(/\.git$/i, "").replace(/\.+$/, "");
+  if (!repo) return undefined;
+  return `${owner}/${repo}`;
+}
+
+/** keeps the first spelling seen, github itself is case insensitive */
+function dedupe(ids: string[]) {
+  const seen = new Map<string, string>();
+  for (const id of ids) {
+    const key = id.toLowerCase();
+    if (!seen.has(key)) seen.set(key, id);
+  }
+  return [...seen.values()];
+}
+
+async function collectSources() {
+  const config = await loadConfig();
+  const only = flags.only?.split(",").map((x) => x.trim().toLowerCase());
+  const entries = only
+    ? config.repos.filter((x) => only.includes(x.name.toLowerCase()))
+    : config.repos;
+
+  if (only) {
+    const unknown = only.filter(
+      (name) => !config.repos.some((x) => x.name.toLowerCase() === name),
+    );
+    if (unknown.length) {
+      console.error(`unknown config.yaml entries: ${unknown.join(", ")}`);
+      process.exit(1);
+    }
+  }
+
+  return dedupe(
+    entries.flatMap(
+      (entry) =>
+        getAwesomeSourceIdsFromConfig(config, entry.name.toLowerCase()) ?? [],
+    ),
+  );
+}
+
+/** refreshes the README of every awesome list and returns the repos they link */
+async function crawlAwesomeLists(sourceIds: string[]) {
+  const stored = await db
+    .select({
+      id: awesomeRepoTable.id,
+      items: awesomeRepoTable.items,
+      digest: awesomeRepoTable.readmeDigest,
+    })
+    .from(awesomeRepoTable)
+    .where(D.inArray(awesomeRepoTable.id, sourceIds));
+  const byId = new Map(stored.map((x) => [x.id, x]));
+
+  if (flags["skip-readme"]) {
+    console.log(`[lists] reusing ${stored.length} cached list(s)`);
+    return dedupe(stored.flatMap((x) => x.items));
+  }
+
+  const queue = new PQueue({ concurrency: CONCURRENCY });
+  const items: string[][] = [];
+  let unchanged = 0;
+
+  await queue.addAll(
+    sourceIds.map((id) => async () => {
+      const result = await withRetry(id, () => fetchAwesomeRepo(id));
+      const cached = byId.get(id);
+      if (!result) {
+        if (cached) items.push(cached.items);
+        console.warn(`[lists] ${id}: unreachable, keeping stored items`);
+        return;
+      }
+      items.push(result.items);
+      if (cached?.digest === result.readmeDigest) {
+        unchanged++;
+        return;
+      }
+      if (DRY_RUN) return;
+      await db
+        .insert(awesomeRepoTable)
+        .values({
+          id,
+          readmeDigest: result.readmeDigest,
+          items: result.items,
+        })
+        .onConflictDoUpdate({
+          target: awesomeRepoTable.id,
+          set: {
+            readmeDigest: D.sql`excluded.readme_digest`,
+            items: D.sql`excluded.items`,
+            updatedAt: new Date(),
+          },
+        });
+    }),
+  );
+
+  console.log(
+    `[lists] ${sourceIds.length} list(s) read, ${unchanged} unchanged since last run`,
+  );
+  return dedupe(items.flat());
+}
+
+/** drops repos refreshed recently and orders the rest stalest first */
+async function selectTargets(ids: string[]) {
+  const rows = await db
+    .select({ id: githubRepoTable.id, updatedAt: githubRepoTable.updatedAt })
+    .from(githubRepoTable);
+  const seenAt = new Map(rows.map((x) => [x.id, x.updatedAt?.getTime() ?? 0]));
+
+  let targets = ids;
+  if (STALE_DAYS !== undefined) {
+    const cutoff = Date.now() - STALE_DAYS * 24 * 60 * 60 * 1000;
+    targets = targets.filter((id) => (seenAt.get(id) ?? 0) < cutoff);
+    console.log(
+      `[repos] ${ids.length - targets.length} refreshed less than ${STALE_DAYS}d ago, skipped`,
+    );
+  }
+  // never seen (0) first, then oldest refresh first
+  targets = targets.toSorted(
+    (a, b) => (seenAt.get(a) ?? 0) - (seenAt.get(b) ?? 0),
+  );
+  if (MAX_REPOS !== undefined && targets.length > MAX_REPOS) {
+    console.log(`[repos] capped at ${MAX_REPOS} of ${targets.length}`);
+    targets = targets.slice(0, MAX_REPOS);
+  }
+  return targets;
+}
+
+async function persist(projects: Map<string, GithubProject>) {
+  if (DRY_RUN || projects.size === 0) return;
+  const now = new Date();
+  const rows = [...projects].map(([id, p]) => ({
+    id,
+    name: p.name,
+    description: p.description,
+    topics: p.topics,
+    owner: p.owner,
+    stars: p.stars,
+    license: p.license ?? null,
+    forks: p.forks,
+    primaryLanguage: p.primaryLanguage,
+    pushedAt: p.pushedAt,
+    archived: p.archived,
+    createdAt: p.createdAt,
+    updatedAt: now,
+  }));
+  // stars_detail / npm_* / go_* are owned by other passes, leave them alone
+  await db
+    .insert(githubRepoTable)
+    .values(rows)
+    .onConflictDoUpdate({
+      target: githubRepoTable.id,
+      set: {
+        name: D.sql`excluded.name`,
+        description: D.sql`excluded.description`,
+        topics: D.sql`excluded.topics`,
+        owner: D.sql`excluded.owner`,
+        stars: D.sql`excluded.stars`,
+        license: D.sql`excluded.license`,
+        forks: D.sql`excluded.forks`,
+        primaryLanguage: D.sql`excluded.primary_language`,
+        pushedAt: D.sql`excluded.pushed_at`,
+        archived: D.sql`excluded.archived`,
+        createdAt: D.sql`excluded.created_at`,
+        updatedAt: D.sql`excluded.updated_at`,
+      },
+    });
+}
+
+async function crawlRepos(ids: string[]) {
+  const batches: string[][] = [];
+  for (let i = 0; i < ids.length; i += BATCH_SIZE) {
+    batches.push(ids.slice(i, i + BATCH_SIZE));
+  }
+
+  const queue = new PQueue({ concurrency: CONCURRENCY });
+  let done = 0;
+  let updated = 0;
+  let missing = 0;
+
+  await queue.addAll(
+    batches.map((batch, i) => async () => {
+      const result = await withRetry(`batch ${i}`, () =>
+        fetchGithubProjects(batch),
+      );
+      done++;
+      if (!result) return;
+      await persist(result.projects);
+      updated += result.projects.size;
+      missing += result.missing.length;
+
+      const { rateLimit } = result;
+      if (done % 10 === 0 || done === batches.length) {
+        console.log(
+          `[repos] ${done}/${batches.length} batches, ${updated} updated, ${missing} gone` +
+            (rateLimit ? ` (${rateLimit.remaining} points left)` : ""),
+        );
+      }
+      // stay clear of the window rather than burning into a hard 403
+      if (rateLimit && rateLimit.remaining < rateLimit.cost * 3) {
+        if (!rotateOctokit()) {
+          const waitMs = new Date(rateLimit.resetAt).getTime() - Date.now();
+          console.warn(
+            `[rate limit] budget exhausted, waiting ${Math.round(waitMs / 1000)}s`,
+          );
+          await sleep(Math.min(Math.max(waitMs, 0) + 5_000, 65 * 60_000));
+        }
+      }
+    }),
+  );
+
+  return { updated, missing };
+}
+
+async function main() {
+  const startedAt = Date.now();
+  const sourceIds = await collectSources();
+  console.log(`[lists] ${sourceIds.length} awesome list(s) from config.yaml`);
+
+  const linked = await crawlAwesomeLists(sourceIds);
+  const candidates = dedupe(
+    [...sourceIds, ...linked]
+      .map(normalizeId)
+      .filter((x): x is string => x !== undefined),
+  );
+  console.log(`[repos] ${candidates.length} unique repositories linked`);
+
+  const targets = await selectTargets(candidates);
+  if (targets.length === 0) {
+    console.log("[repos] nothing to refresh");
+    return;
+  }
+
+  const { updated, missing } = await crawlRepos(targets);
+  console.log(
+    `[done] ${updated} repositories refreshed, ${missing} gone, ` +
+      `${Math.round((Date.now() - startedAt) / 1000)}s` +
+      (DRY_RUN ? " (dry run, nothing written)" : ""),
+  );
+}
+
+await main();

--- a/config.yaml
+++ b/config.yaml
@@ -76,7 +76,7 @@ repos:
       - https://github.com/jaywcjlove/awesome-mac
     icon: 🍏
   - name: Zig
-    url: https://github.com/catdevnull/awesome-zig
+    url: https://github.com/zigcc/awesome-zig
     icon: 🧩
   - name: TinyJS
     url: https://github.com/thoughtspile/awesome-tiny-js

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "drizzle-kit";
 export default defineConfig({
   dialect: "sqlite",
-  schema: "./lib/db/schema.mts",
+  schema: "./lib/db/schema.ts",
   out: "./migration",
   dbCredentials: {
     url: "sqlite.db",

--- a/lib/fetcher/github.ts
+++ b/lib/fetcher/github.ts
@@ -8,10 +8,20 @@ function hasMoreToken() {
   return tokens.length > 0;
 }
 function invalidThisOctokit(octokit: any) {
-  if (octokit === _octokit) {
+  // only drop the current client when a replacement token is available,
+  // otherwise every later getOctokit() would throw NoMoreTokenError
+  if (octokit === _octokit && hasMoreToken()) {
     console.log("tokens iv");
     _octokit = undefined;
   }
+}
+
+// switch to the next token, if any. returns false when this was the last one,
+// in which case the caller has to wait for the rate limit window to reset.
+export function rotateOctokit() {
+  if (!hasMoreToken()) return false;
+  _octokit = undefined;
+  return true;
 }
 
 class NoMoreTokenError extends Error {
@@ -78,6 +88,7 @@ export async function fetchGithubProject(id: string) {
   for (const lang of Object.keys(languagesData)) {
     if (languagesData[lang] > maxCount) {
       primaryLanguage = lang;
+      maxCount = languagesData[lang];
     }
   }
 
@@ -97,6 +108,104 @@ export async function fetchGithubProject(id: string) {
     license: repoData.license?.name,
     description: repoData.description || "",
     primaryLanguage,
+  };
+}
+
+export type GithubProject = Awaited<ReturnType<typeof fetchGithubProject>>;
+
+const REPO_FIELDS = `
+fragment repoFields on Repository {
+  nameWithOwner
+  url
+  description
+  isArchived
+  stargazerCount
+  forkCount
+  pushedAt
+  createdAt
+  licenseInfo { name }
+  primaryLanguage { name }
+  repositoryTopics(first: 10) { nodes { topic { name } } }
+  owner { login avatarUrl }
+}`;
+
+/**
+ * Batched variant of fetchGithubProject.
+ *
+ * The REST version costs 2 requests per repository, which does not fit in the
+ * 5000 req/hour budget for a dataset of ~18k repositories. GraphQL resolves a
+ * whole batch with a single request costing 1 rate limit point, and returns the
+ * primary language directly so the extra listLanguages call is not needed.
+ *
+ * Repositories that were deleted or made private resolve to `null` instead of
+ * failing the whole batch.
+ */
+export async function fetchGithubProjects(ids: string[]) {
+  const octokit = getOctokit();
+
+  const varDefs: string[] = [];
+  const selections: string[] = [];
+  const variables: Record<string, string> = {};
+  ids.forEach((id, i) => {
+    const [owner, repo] = id.split("/");
+    varDefs.push(`$o${i}: String!`, `$n${i}: String!`);
+    selections.push(
+      `r${i}: repository(owner: $o${i}, name: $n${i}) { ...repoFields }`,
+    );
+    variables[`o${i}`] = owner;
+    variables[`n${i}`] = repo;
+  });
+
+  const query = `query batch(${varDefs.join(", ")}) {
+  rateLimit { cost remaining resetAt }
+  ${selections.join("\n  ")}
+}${REPO_FIELDS}`;
+
+  let data: any;
+  try {
+    data = await octokit.graphql(query, variables);
+  } catch (e: any) {
+    // a NOT_FOUND on any alias makes the whole call reject, but the payload
+    // still carries every repository that did resolve
+    if (e && typeof e === "object" && "data" in e && e.data) {
+      data = e.data;
+    } else {
+      throw e;
+    }
+  }
+
+  const projects = new Map<string, GithubProject>();
+  ids.forEach((id, i) => {
+    const node = data[`r${i}`];
+    if (!node) return;
+    projects.set(id, {
+      url: node.url,
+      name: node.nameWithOwner,
+      topics: (node.repositoryTopics?.nodes || []).map(
+        (x: any) => x.topic.name,
+      ),
+      stars: node.stargazerCount,
+      owner: {
+        // rendered as a github.com/<name> link, so it has to stay the login
+        name: node.owner.login,
+        avatarUrl: node.owner.avatarUrl,
+      },
+      forks: node.forkCount || 0,
+      pushedAt: new Date(node.pushedAt ?? node.createdAt),
+      createdAt: new Date(node.createdAt),
+      archived: node.isArchived,
+      license: node.licenseInfo?.name,
+      description: node.description || "",
+      primaryLanguage: node.primaryLanguage?.name || "",
+    });
+  });
+
+  return {
+    projects,
+    missing: ids.filter((id) => !projects.has(id)),
+    rateLimit: data.rateLimit as
+      | { cost: number; remaining: number; resetAt: string }
+      | undefined,
   };
 }
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "private": true,
   "scripts": {
     "build": "next build",
+    "migrate": "drizzle-kit migrate",
+    "crawl": "tsx bin/crawl.ts",
     "publish": "gh-pages --dotfiles -d out  -b pages -r git@github.com:AweXplor/AweXplor.github.io.git --user \"adevday <124041366+adevday@users.noreply.github.com>\""
   },
   "imports": {

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,5 @@
+allowBuilds:
+  better-sqlite3: true
+  canvas: true
+  esbuild: true
+  sharp: true


### PR DESCRIPTION
Hey! The published pages are serving data crawled on 2025-05-10, so every card's
"last activity" is more than a year stale, and sort-by-activity and
filter-unmaintained rank on numbers that stopped being true a while ago. I went
digging to see if I could just re-run the crawl myself, and ended up with this.

`pushed_at` is captured at crawl time and frozen into
`public/aggregated/<list>.json` at build time, so the site can only ever be as
fresh as the last crawl. The crawler that produced `sqlite.db` isn't in the repo
(`/bin` is gitignored) — but that turned out not to be the real blocker.
`pnpm build` doesn't complete right now, for three unrelated reasons:

1. `notion.so` returns 403 to node's default user agent, which kills the export
   on the home page. A browser UA is enough to fix it.
2. Notion now nests every record under an extra `value` level (`__version__` 3)
   while `react-notion-x` still reads the flat shape, so rendering then crashes
   on `undefined.replaceAll`.
3. `public/aggregated` isn't tracked by git, so on a fresh checkout every
   `writeFile` fails inside a `try/catch` that only logs. That's the nasty one —
   the build goes green and ships a site whose data files are all missing.

### The crawler

`bin/crawl.ts` reads the lists from `config.yaml`, pulls the repos out of each
README and refreshes their metadata.

I couldn't use `fetchGithubProject` as the main path: at 2 requests per repo
that's ~40k for the whole dataset, against 5000/hour per account — which is also
why the comma-separated token list only buys you anything if the tokens belong
to different accounts, since same-account PATs share one quota. So there's a
`fetchGithubProjects` next to it that resolves a whole batch over GraphQL for 1
rate limit point. A full refresh is 20,377 repos in 409 requests and 408 points,
about 9 minutes. As a bonus GraphQL hands you `primaryLanguage` directly, so
`listLanguages` isn't needed at all.

Rate limits are treated as something that just happens rather than an error:
rotate to the next token on 403, otherwise sleep until `x-ratelimit-reset`, and
back off before the budget runs out. Rows are written batch by batch so an
interrupted run keeps what it managed to get, and `--stale-days` / `--max-repos`
let you cap a run and resume later.

Two things I fixed while I was in there. `fetchGithubProject` never updated
`maxCount`, so `primaryLanguage` ended up being the *last* language above zero
instead of the biggest one — Deno is currently tagged Shell. And
`invalidThisOctokit` dropped the client even when no replacement token was left,
which makes every later `getOctokit()` throw for the rest of the run.
`drizzle.config.ts` also points at `lib/db/schema.mts`, which doesn't exist.

### The workflow

Daily, plus manual dispatch. `sqlite.db` isn't tracked, so it lives between runs
as a gzipped release asset (3 MB), uploaded even when the crawl dies halfway so
the next run picks up instead of starting over. It works on the built-in token;
`CRAWL_GITHUB_TOKEN` is there if you want more headroom.

I ran the whole thing end to end on my fork, starting from an empty database:

https://github.com/dnldsht/awexplor.github.io/actions/runs/31588459082

26 minutes for crawl → release asset → build → deploy. It walked into the
secondary rate limit near the end (batches 409-416) and waited it out without
losing anything — 25 minutes for the crawl there versus 9 locally with a PAT.
Only ~420 of the 5000 GraphQL points were spent, so what actually bites is
request pacing, not the budget.

The result is live at
https://dnldsht.github.io/awexplor.github.io/aggregated/selfhosted — 907 of
those 1070 repos now say *Recently* instead of "a year ago". That branch carries
one extra commit that isn't in this PR: a fork gets served under a subfolder, and
`basePath` doesn't rewrite the plain anchors or the runtime json fetch.

### Two things I left alone

`catdevnull/awesome-zig` 404s, so `/aggregated/zig` was being exported with zero
repos. I pointed it at `zigcc/awesome-zig`, which gives 526 — but that's a
curation call, so drop that commit if you'd rather pick a different one.

Star history I deliberately didn't touch. `stars_detail` drives the default
ordering and the trending block, and refreshing it means walking the stargazers
of every repo: roughly 189k requests, ~38 hours of quota. That didn't feel like
my call to make, so the crawl leaves those columns alone and your existing values
keep working. One thing worth knowing if you ever put it on a schedule:
`fetchRepoStarSummary` sometimes returns its internal binary-search tuple instead
of a count — `"month": [65, 84, 1733353428]` is in the json being served today.

Two last notes. GitHub disables scheduled workflows after 60 days of repo
inactivity, so the daily run needs either some activity or an occasional manual
kick. And `pnpm-workspace.yaml` is in here because without it `pnpm install`
fails with `ERR_PNPM_IGNORED_BUILDS` and never builds `better-sqlite3`.

Happy to split this up or change any of it — it's your project, and I know four
commits' worth of unsolicited changes is a lot to land in one go.
